### PR TITLE
修复 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,4 +234,4 @@ docker compose up
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=johnson7788/MultiAgentPPT&type=Date)](https://www.star-history.com/#johnson7788/MultiAgentPPT&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=johnson7788/MultiAgentPPT&type=Date)](https://star-history.dera.page/#johnson7788/MultiAgentPPT&Date)


### PR DESCRIPTION
当前的 Star History 图表因 GitHub 星标接口限制而无法正常显示，现将图表与链接切换到 star-history.dera.page，恢复 Star History 图表的正常展示。